### PR TITLE
OS X: Indentation and syntax

### DIFF
--- a/BBGE/Cocoa.mm
+++ b/BBGE/Cocoa.mm
@@ -12,9 +12,9 @@
 void cocoaMessageBox(const std::string &title, const std::string &msg)
 {
     @autoreleasepool {
-    NSString *nstitle = @(title.c_str());
-    NSString *nsmsg = @(msg.c_str());
-    NSRunAlertPanel(nstitle, nsmsg, nil, nil, nil);
+        NSString *nstitle = @(title.c_str());
+        NSString *nsmsg = @(msg.c_str());
+        NSRunAlertPanel(nstitle, nsmsg, nil, nil, nil);
     }
 }
 


### PR DESCRIPTION
These set of patches updates some OS X code to use more modern Objective-C syntax, as well as intending the code.
