### PR TITLE
Update Core.cpp

### DIFF
--- a/BBGE/Core.cpp
+++ b/BBGE/Core.cpp
@@ -63,6 +63,10 @@ Core *core = 0;
 	HICON icon_windows = 0;
 #endif
 
+#ifndef KMOD_GUI
+	#define KMOD_GUI KMOD_META
+#endif
+
 void Core::initIcon()
 {
 #ifdef BBGE_BUILD_WINDOWS


### PR DESCRIPTION
Had a little issue building today on OS X Mavericks with both SDL and SDL2 installed via Homebrew. Saw that KMOD_GUI is no longer #define-d in SDL/SDL_keysym.h, so added an #ifndef directive.
