### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/ExternalLibs/minihttp.cpp
+++ b/ExternalLibs/minihttp.cpp
@@ -33,6 +33,7 @@
 #  include <unistd.h>
 #  include <fcntl.h>
 #  include <sys/socket.h>
+#  include <netinet/in.h>
 #  include <netdb.h>
 #  define SOCKET_ERROR (-1)
 #  define INVALID_SOCKET (SOCKET)(~0)


### PR DESCRIPTION
FreeBSD and other BSD descendants have `struct sockaddr_in` defined in `<netinet/in.h>`. According to [POSIX](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html) it's also there. So, Linux and OS X probably bootleg it via other headers.

```
ExternalLibs/minihttp.cpp:254:17: error: variable has incomplete type 'minihttp::sockaddr_in'
    sockaddr_in addr;
                ^
ExternalLibs/minihttp.cpp:103:66: note: forward declaration of 'minihttp::sockaddr_in'
static bool _Resolve(const char *host, unsigned int port, struct sockaddr_in *addr)
                                                                 ^
1 error generated.
```
