### PR TITLE
Get rid of a lot of warnings 

### DIFF
--- a/Aquaria/AnimationEditor.cpp
+++ b/Aquaria/AnimationEditor.cpp
@@ -1111,8 +1111,8 @@ void AnimationEditor::flipRot()
 		{
 			BoneKeyframe *bcur = editSprite->getCurrentAnimation()->getKeyframe(currentKey)->getBoneKeyframe(editingBone->boneIdx);
 			if (bcur)
-			{
-				int rotdiff = editingBone->rotation.z - bcur->rot;
+            {
+                // int rotdiff = editingBone->rotation.z - bcur->rot;
 				if (!core->getCtrlState())
 				{
 					for (int i = 0; i < editSprite->getCurrentAnimation()->getNumKeyframes(); ++i)

--- a/Aquaria/AquariaMenuItem.cpp
+++ b/Aquaria/AquariaMenuItem.cpp
@@ -695,6 +695,8 @@ void AquariaKeyConfig::onUpdate(float dt)
 			}
 		}
 		break;
+        case INPUTSET_NONE:
+        break;
 		}
 	}
 

--- a/Aquaria/Avatar.cpp
+++ b/Aquaria/Avatar.cpp
@@ -54,7 +54,7 @@ int SongIcon::notesOpen = 0;
 Avatar *avatar = 0;
 const Vector BLIND_COLOR = Vector(0.1, 0.1, 0.1);
 const float ANIM_TRANSITION	= 0.2;
-const float MANA_RECHARGE_RATE = 1.0;
+//const float MANA_RECHARGE_RATE = 1.0;
 const int AURA_SHIELD_RADIUS = 64;
 //const int TARGET_RANGE = 1024;
 const int TARGET_RANGE = 1024; // 650
@@ -69,7 +69,7 @@ const int BURST_DISTANCE = 200;
 const int STOP_DISTANCE = 48;
 const int maxMouse = BURST_DISTANCE;
 //const int SHOCK_RANGE	= 700;
-const int SHOCK_RANGE	= 1000;
+//const int SHOCK_RANGE	= 1000;
 const int SPIRIT_RANGE	= 2000;
 
 const float QUICK_SONG_CAST_DELAY = 0.4;
@@ -81,9 +81,9 @@ const float BURST_ACCEL = 4000; //2000 // 1000
 // Minimum time between two splash effects (seconds).
 const float SPLASH_INTERVAL = 0.2;
 
-const float TUMMY_TIME = 6.0;
+//const float TUMMY_TIME = 6.0;
 
-const float chargeMax = 2.0;
+//const float chargeMax = 2.0;
 
 // Axis input distance (0.0-1.0) at which we start moving.
 const float JOYSTICK_LOW_THRESHOLD = 0.2;
@@ -861,7 +861,17 @@ std::string Avatar::getIdleAnimName()
 	{
 	case FORM_ENERGY:
 		ret="energyidle";
-	break;
+    break;
+    case FORM_NORMAL:
+    case FORM_BEAST:
+    case FORM_NATURE:
+    case FORM_SPIRIT:
+    case FORM_DUAL:
+    case FORM_FISH:
+    case FORM_SUN:
+    case FORM_MAX:
+    case FORM_NONE:
+        break;
 	}
 	return ret;
 }
@@ -1231,7 +1241,11 @@ void Avatar::entityDied(Entity *e)
 			{
 				dsq->continuity.eatBeast(e->eatData);
 			}
-			break;
+            break;
+        case EAT_DEFAULT:
+        case EAT_MAX:
+        case EAT_NONE:
+            break;
 		}
 	}
 
@@ -1582,6 +1596,9 @@ void Avatar::changeForm(FormType form, bool effects, bool onInit, FormType lastF
 		case FORM_DUAL:
 			core->sound->playSfx("DualForm");
 		break;
+        case FORM_NONE:
+        case FORM_MAX:
+        break;
 		}
 
 		/*
@@ -2819,6 +2836,10 @@ void Avatar::formAbility(int ability)
 
 	}
 	break;
+    case FORM_NORMAL:
+    case FORM_NONE:
+    case FORM_MAX:
+    break;
 	}
 }
 
@@ -2979,7 +3000,7 @@ void Avatar::doShock(const std::string &shotName)
 					}
 				}
 				*/
-				Vector d = e->position - position;
+                // Vector d = e->position - position;
 				/*
 				float a = float(float(i)/float(sz))*PI*2;
 				Vector aim(sinf(a), cosf(a));
@@ -3034,11 +3055,17 @@ void Avatar::formAbilityUpdate(float dt)
 		}
 	}
 	break;
-	case FORM_ENERGY:
-	{
-	}
-	break;
-	}
+    case FORM_ENERGY:
+    case FORM_NORMAL:
+    case FORM_BEAST:
+    case FORM_NATURE:
+    case FORM_SPIRIT:
+    case FORM_DUAL:
+    case FORM_SUN:
+    case FORM_MAX:
+    case FORM_NONE:
+        break;
+    }
 }
 
 bool Avatar::isMouseInputEnabled()
@@ -3128,7 +3155,13 @@ bool Avatar::canCharge(int ability)
 	break;
 	case FORM_SUN:
 		return true;
-	break;
+    break;
+    case FORM_NORMAL:
+    case FORM_SPIRIT:
+    case FORM_FISH:
+    case FORM_MAX:
+    case FORM_NONE:
+        break;
 	}
 	return false;
 }
@@ -4720,7 +4753,11 @@ void Avatar::updateAura(float dt)
 				}
 			}
 		}
-		break;
+        break;
+        case AURA_THING:
+        case AURA_HEAL:
+        case AURA_NONE:
+            break;
 		}
 
 		auraTimer -= dt;
@@ -4864,7 +4901,15 @@ void Avatar::updateFormVisualEffects(float dt)
 	case FORM_SPIRIT:
 		skeletalSprite.update(dt);
 		skeletalSprite.position = bodyPosition;
-	break;
+    break;
+    case FORM_NORMAL:
+    case FORM_BEAST:
+    case FORM_NATURE:
+    case FORM_DUAL:
+    case FORM_FISH:
+    case FORM_MAX:
+    case FORM_NONE:
+        break;
 	}
 }
 
@@ -5975,7 +6020,7 @@ void Avatar::onUpdate(float dt)
 			{
 				if (state.spellCharge > 1.5f && chargeLevelAttained <1)
 				{
-					chargeLevelAttained = 1.5;
+                    chargeLevelAttained = 1;
 					core->sound->playSfx("PowerUp");
 					chargingEmitter->load("ChargingEnergy2");
 				}
@@ -6026,7 +6071,14 @@ void Avatar::onUpdate(float dt)
 					chargingEmitter->start();
 				}
 			}
-			break;
+            break;
+            case FORM_NORMAL:
+            case FORM_BEAST:
+            case FORM_SPIRIT:
+            case FORM_FISH:
+            case FORM_MAX:
+            case FORM_NONE:
+                break;
 			}
 		}
 		/*

--- a/Aquaria/CollideEntity.cpp
+++ b/Aquaria/CollideEntity.cpp
@@ -93,6 +93,8 @@ void CollideEntity::bounce(float ba)
 		}
 	}
 	break;
+    case BOUNCE_NONE:
+    break;
 	}
 
 

--- a/Aquaria/Continuity.cpp
+++ b/Aquaria/Continuity.cpp
@@ -607,6 +607,10 @@ std::string Continuity::getIEString(IngredientData *data, int i)
 			return ret;
 		}
 	break;
+    case IET_NONE:
+    case IET_RANDOM:
+    case IET_MAX:
+        break;
 	}
 
 	return "";
@@ -1241,6 +1245,9 @@ std::string Continuity::getInternalFormName()
 		return "sun";
 	case FORM_DUAL:
 		return "dual";
+    case FORM_NONE:
+    case FORM_MAX:
+        break;
 	}
 	return "";
 }
@@ -1634,8 +1641,12 @@ void Continuity::castSong(int num)
 		case SONG_FISHFORM:
 			dsq->game->avatar->changeForm(FORM_FISH);
 		break;
-		case SONG_SONGDOOR1:
-		break;
+        case SONG_SONGDOOR1:
+        case SONG_SONGDOOR2:
+        case SONG_ANIMA:
+        case SONG_NONE:
+        case SONG_MAX:
+        break;
 #endif
 		}
 	}

--- a/Aquaria/DSQ.cpp
+++ b/Aquaria/DSQ.cpp
@@ -1782,6 +1782,8 @@ void DSQ::toggleInputMode()
 	case INPUT_JOYSTICK:
 		setInputMode(INPUT_MOUSE);
 	break;
+    case INPUT_KEYBOARD:
+    break;
 	}
 }
 
@@ -1799,6 +1801,8 @@ void DSQ::setInputMode(InputMode mode)
 		core->joystickAsMouse = false;
 		updateCursorFromMouse = true;
 	break;
+    case INPUT_KEYBOARD:
+    break;
 	}
 }
 
@@ -4091,6 +4095,8 @@ void DSQ::onUpdate(float dt)
 			case INPUT_JOYSTICK:
 				os << "joystick";
 			break;
+            case INPUT_KEYBOARD:
+            break;
 			}
 			os << std::endl;
 			Bone *b = dsq->game->avatar->skeletalSprite.getBoneByIdx(1);

--- a/Aquaria/DSQ.h
+++ b/Aquaria/DSQ.h
@@ -683,7 +683,7 @@ enum FoodSortType
 
 struct IngredientEffect
 {
-	IngredientEffect() : type(IET_NONE), magnitude(0) {}
+    IngredientEffect() : magnitude(0), type(IET_NONE) {}
 	float magnitude;
 	IngredientEffectType type;
 	std::string string;

--- a/Aquaria/Element.cpp
+++ b/Aquaria/Element.cpp
@@ -22,18 +22,18 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "Game.h"
 
 ElementEffectData::ElementEffectData()
-	: elementEffectIndex(-1)
-	, wavyAngleOffset(0)
-	, wavyMagnitude(0)
-	, wavyLerpIn(0)
-	, wavyMin(0)
-	, wavyMax(0)
-	, hitPerc(0)
-	, effectMult(0)
-	, wavyWaving(false)
-	, wavyFlip(false)
-	, touching(false)
-	, elementEffectType(EFX_NONE)
+    : elementEffectType(EFX_NONE)
+    , wavyAngleOffset(0)
+    , wavyMagnitude(0)
+    , wavyLerpIn(0)
+    , wavyMin(0)
+    , wavyMax(0)
+    , hitPerc(0)
+    , effectMult(0)
+    , wavyWaving(false)
+    , wavyFlip(false)
+    , touching(false)
+    , elementEffectIndex(-1)
 {
 }
 

--- a/Aquaria/Entity.cpp
+++ b/Aquaria/Entity.cpp
@@ -1001,8 +1001,6 @@ const float sct = 0.15;
 const float blurMax = 0.01;
 const float blurMin = 0.0;
 
-
-
 void Entity::onFHScale()
 {
 	flipScale.interpolateTo(Vector(1, 1), sct);

--- a/Aquaria/Entity.cpp
+++ b/Aquaria/Entity.cpp
@@ -998,9 +998,6 @@ bool Entity::touchAvatarDamage(int radius, float dmg, const Vector &override, fl
 
 const float sct = 0.15;
 
-const float blurMax = 0.01;
-const float blurMin = 0.0;
-
 void Entity::onFHScale()
 {
 	flipScale.interpolateTo(Vector(1, 1), sct);

--- a/Aquaria/Game.cpp
+++ b/Aquaria/Game.cpp
@@ -156,7 +156,7 @@ void PetSlot::onUpdate(float dt)
 	}
 }
 
-FoodHolder::FoodHolder(int slot, bool trash) : Quad(), slot(slot), trash(trash)
+FoodHolder::FoodHolder(int slot, bool trash) : Quad(), trash(trash), slot(slot)
 {
 	foodHolderIngredient = 0;
 	buttonDown = false;
@@ -1020,7 +1020,7 @@ public:
 
 Vector menuBgScale;
 
-const int ITEMS_PER_PAGE = 12;
+//const int ITEMS_PER_PAGE = 12;
 
 ObsRow::ObsRow(int tx, int ty, int len) : tx(tx), ty(ty), len(len)
 {
@@ -2244,7 +2244,7 @@ float Game::getCoverage(Vector pos, int sampleArea)
 		{
 			if (x == t.x && y == t.y) continue;
 			TileVector ct(x,y);
-			Vector vt = ct.worldVector();
+            //Vector vt = ct.worldVector();
 			if (isObstructed(ct))
 			{
 				covered++;
@@ -8250,11 +8250,9 @@ void Game::playBurstSound(bool wallJump)
 	sound->playSfx("Burst", 1);
 	if (chance(50))
 	{
-		switch (dsq->continuity.form)
-		{
-		case FORM_BEAST:
-			sound->playSfx("BeastBurst", (128+rand()%64)/256.0f);
-		break;
+        if (dsq->continuity.form == FORM_BEAST)
+        {
+            sound->playSfx("BeastBurst", (128+rand()%64)/256.0f);
 		}
 	}
 }
@@ -10404,7 +10402,7 @@ void Game::update(float dt)
 			dsq->cameraPos = getCameraPositionFor(cameraInterp);
 			constrainCamera();
 
-			float dd = (dsq->cameraPos - oldCamPos).getLength2D();
+            //float dd = (dsq->cameraPos - oldCamPos).getLength2D();
 		}
 
 		cameraInterp.update(dt);

--- a/Aquaria/Game.h
+++ b/Aquaria/Game.h
@@ -363,7 +363,7 @@ class EntityClass
 {
 public:
 	EntityClass(std::string name, bool script=false, int idx=-1, std::string prevGfx="", float prevScale=1)
-		: name(name), script(script), idx(idx), prevGfx(prevGfx), prevScale(prevScale) {}
+        : name(name), prevScale(prevScale), prevGfx(prevGfx), script(script), idx(idx) {}
 	std::string name;
 	float prevScale;
 	std::string prevGfx;

--- a/Aquaria/Ingredient.cpp
+++ b/Aquaria/Ingredient.cpp
@@ -22,9 +22,15 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "Avatar.h"
 
 IngredientData::IngredientData(const std::string &name, const std::string &gfx, IngredientType type)
-: name(name), gfx(gfx), amount(0), maxAmount(MAX_INGREDIENT_AMOUNT), held(0), type(type), marked(0), sorted(false)
-, displayName(dsq->continuity.getIngredientDisplayName(name))
-, rotKind(!(type == IT_OIL || type == IT_EGG))
+    : name(name)
+    , gfx(gfx)
+    , displayName(dsq->continuity.getIngredientDisplayName(name))
+    , type(type)
+    , amount(0)
+    , maxAmount(MAX_INGREDIENT_AMOUNT)
+    , held(0)
+    , marked(0)
+    , rotKind(!(type == IT_OIL || type == IT_EGG))
 {
 }
 
@@ -44,7 +50,11 @@ bool IngredientData::hasIET(IngredientEffectType iet)
 }
 
 Ingredient::Ingredient(const Vector &pos, IngredientData *data, int amount)
- : Entity(),  data(data), amount(amount), gone(false), used(false)
+    : Entity()
+    , data(data)
+    , used(false)
+    , gone(false)
+    , amount(amount)
 {
 	addType(SCO_INGREDIENT);
 	entityType = ET_INGREDIENT;

--- a/Aquaria/Logo.h
+++ b/Aquaria/Logo.h
@@ -27,7 +27,7 @@ class Logo : public StateObject
 {
 public:
 	Logo();
-	EVENT(JumpTitle, jumpTitle);
+    EVENT(JumpTitle, jumpTitle)
 	void applyState();
 	void removeState();
 };

--- a/Aquaria/MiniMapRender.cpp
+++ b/Aquaria/MiniMapRender.cpp
@@ -611,8 +611,8 @@ void MiniMapRender::onRender()
 				}
 
 				if (render)
-				{
-					renderIcon(p->minimapIcon, p->nodes[0].position);
+                {
+                    renderIcon(p->minimapIcon, p->nodes[0].position);
 				}
 			}
 		}

--- a/Aquaria/ModSelector.cpp
+++ b/Aquaria/ModSelector.cpp
@@ -41,8 +41,13 @@ static bool _modname_cmp(const ModIcon *a, const ModIcon *b)
 	return a->fname < b->fname;
 }
 
-ModSelectorScreen::ModSelectorScreen() : Quad(), ActionMapper(),
-currentPanel(-1), gotServerList(false), dlText(&dsq->smallFont), subtext(&dsq->subsFont)
+ModSelectorScreen::ModSelectorScreen()
+    : Quad()
+    , ActionMapper()
+    , dlText(&dsq->smallFont)
+    , gotServerList(false)
+    , currentPanel(-1)
+    , subtext(&dsq->subsFont)
 {
 	followCamera = 1;
 	shareAlphaWithChildren = false;
@@ -131,7 +136,7 @@ void ModSelectorScreen::showPanel(int id)
 	if(id == currentPanel)
 		return;
 
-	const float t = 0.2f;
+    //const float t = 0.2f;
 	IconGridPanel *newgrid = panels[id];
 
 	// fade in selected panel
@@ -478,7 +483,11 @@ void BasicIcon::onClick()
 	dsq->sound->playSfx("denied");
 }
 
-MenuIcon::MenuIcon(int id) : SubtitleIcon(), iconId(id), cb(0), cb_data(0)
+MenuIcon::MenuIcon(int id)
+    : SubtitleIcon()
+    , cb(0)
+    , cb_data(0)
+    , iconId(id)
 {
 }
 
@@ -614,7 +623,13 @@ void ModIcon::updateStatus()
 
 
 ModIconOnline::ModIconOnline()
-: SubtitleIcon(), pb(0), extraIcon(0), statusIcon(0), clickable(true), pkgtype(MPT_MOD), hasUpdate(false)
+    : SubtitleIcon()
+    , pb(0)
+    , extraIcon(0)
+    , statusIcon(0)
+    , pkgtype(MPT_MOD)
+    , clickable(true)
+    , hasUpdate(false)
 {
 	label = desc;
 }
@@ -872,7 +887,7 @@ void MenuIconBar::add(MenuIcon *ico)
 }
 
 IconGridPanel::IconGridPanel()
-: spacing(0), y(0), x(0)
+: spacing(0), x(0), y(0)
 {
 	shareAlphaWithChildren = false; // patch selection icons need their own alpha, use fade() instead
 	alphaMod = 0.01f;

--- a/Aquaria/Network.cpp
+++ b/Aquaria/Network.cpp
@@ -60,7 +60,7 @@ protected:
 
 		minihttp::HttpSocket::_OnOpen();
 
-		const Request& r = GetCurrentRequest();
+        //const Request& r = GetCurrentRequest();
 		// TODO ??
 	}
 

--- a/Aquaria/Path.cpp
+++ b/Aquaria/Path.cpp
@@ -587,9 +587,9 @@ void Path::update(float dt)
 				Vector start = nodes[0].position;
 				Vector end = nodes[1].position;
 				Vector v = end - start;
-				Vector left = v.getPerpendicularLeft();
-				Vector right = v.getPerpendicularRight();
-				Vector mid = (end-start) + start;
+                //Vector left = v.getPerpendicularLeft();
+                //Vector right = v.getPerpendicularRight();
+                //Vector mid = (end-start) + start;
 				FOR_ENTITIES(i)
 				{
 					Entity *e = *i;

--- a/Aquaria/PathFinding.cpp
+++ b/Aquaria/PathFinding.cpp
@@ -28,7 +28,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 class SearchGridRaw
 {
 public:
-	SearchGridRaw(ObsType blocking) : game(dsq->game), blockingObsBits(blocking) {}
+    SearchGridRaw(ObsType blocking) : blockingObsBits(blocking), game(dsq->game) {}
 	inline bool operator()(unsigned x, unsigned y) const
 	{
 		return (game->getGridRaw(TileVector(x, y)) & blockingObsBits) == OT_EMPTY;
@@ -80,7 +80,7 @@ void PathFinding::molestPath(VectorPath &path)
 		Vector node = path.getPathNode(i)->value;
 		float dist;
 		int sample = 20;
-		float maxDist = sample * TILE_SIZE;
+        //float maxDist = sample * TILE_SIZE;
 		{
 			Vector n = dsq->game->getWallNormal(node, sample, &dist);
 			if (dist != -1 && (n.x != 0 || n.y != 0))

--- a/Aquaria/SceneEditor.cpp
+++ b/Aquaria/SceneEditor.cpp
@@ -2863,6 +2863,9 @@ void SceneEditor::updateText()
 		if (getSelectedPath())
 			os << " name: " << getSelectedPath()->name;
 	break;
+    case ET_SELECTENTITY:
+    case ET_MAX:
+        break;
 	}
 	text->setText(os.str());
 }
@@ -2992,6 +2995,10 @@ void SceneEditor::update(float dt)
 			else
 				placer->alpha = 0.5;
 		break;
+        case ET_PATHS:
+        case ET_SELECTENTITY:
+        case ET_MAX:
+            break;
 		}
 
 		updateText();
@@ -3099,6 +3106,9 @@ void SceneEditor::update(float dt)
 				if (selectedIdx >= 0)
 					dsq->game->getPath(selectedIdx)->nodes[selectedNode].position = dsq->getGameCursorPosition() + cursorOffset;
 			break;
+            case ES_ROTATING:
+            case ES_MAX:
+                break;
 			}
 		}
 		else if (editType == ET_ENTITIES)
@@ -3126,6 +3136,11 @@ void SceneEditor::update(float dt)
 					}
 				}
 			}
+                break;
+            case ES_SELECTING:
+            case ES_SCALING:
+            case ES_MAX:
+                break;
 			}
 		}
 		else if (editType == ET_ELEMENTS)
@@ -3193,7 +3208,7 @@ void SceneEditor::update(float dt)
 				else if (cursorOffset.x < oldPosition.x-10)
 					right = false;
 				else
-					noSide++;
+                    noSide = true;
 				if (cursorOffset.y > oldPosition.y+10)
 					down = true;
 				else if (cursorOffset.y < oldPosition.y-10)
@@ -3291,6 +3306,8 @@ void SceneEditor::update(float dt)
 				}
 			}
 			break;
+            case ES_MAX:
+                break;
 			}
 		}
 	}

--- a/Aquaria/SchoolFish.cpp
+++ b/Aquaria/SchoolFish.cpp
@@ -25,10 +25,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 const float strengthSeparation = 1;
 const float strengthAlignment = 0.8f;
-const float strengthAvoidance = 1;
+//const float strengthAvoidance = 1;
 const float strengthCohesion = 0.5f;
 
-const float avoidanceDistance = 128;
+//const float avoidanceDistance = 128;
 const float separationDistance = 128;
 const float minUrgency = 5;//0.05;
 const float maxUrgency = 10;//0.1;

--- a/Aquaria/ScriptInterface.cpp
+++ b/Aquaria/ScriptInterface.cpp
@@ -586,16 +586,6 @@ BaseText *getText(lua_State *L, int slot = 1)
 	return q;
 }
 
-static inline
-Shader *getShader(lua_State *L, int slot = 1)
-{
-	Shader *q = (Shader*)lua_touserdata(L, slot);
-	ENSURE_TYPE(q, SCO_SHADER);
-	if (!q)
-		scriptDebug(L, "Invalid Shader");
-	return q;
-}
-
 static SkeletalSprite *getSkeletalSprite(Entity *e)
 {
 	return e ? &e->skeletalSprite : NULL;
@@ -9706,6 +9696,7 @@ static const struct {
 
 	luaRegister(entity_setDeathParticleEffect),
 	luaRegister(entity_setDeathSound),
+    luaRegister(entity_setStopSoundsOnDeath),
 
 	luaRegister(entity_setDamageTarget),
 	luaRegister(entity_setAllDamageTargets),
@@ -9958,7 +9949,7 @@ static const struct {
 	luaRegister(resetTimer),
 
 	luaRegister(addInfluence),
-	luaRegister(setSuckPosition),
+    luaRegister(getSuckPosition),
 	luaRegister(setSuckPosition),
 	luaRegister(setNumSuckPositions),
 	luaRegister(setupBasicEntity),
@@ -10567,8 +10558,9 @@ static const struct {
 	luaRegister(minimap_setWaterBitTex),
 	luaRegister(minimap_setTopTex),
 	luaRegister(minimap_setBottomTex),
-	luaRegister(minimap_setAvatarIconTex),
-	luaRegister(minimap_setHealthBarTex),
+    luaRegister(minimap_setAvatarIconTex),
+    luaRegister(minimap_setHealthBarTex),
+    luaRegister(minimap_setMaxHealthMarkerTex),
 	luaRegister(entity_mmicon_delete),
 	luaRegister(entity_mmicon_tex),
 	luaRegister(entity_mmicon_size),

--- a/Aquaria/ScriptInterface.cpp
+++ b/Aquaria/ScriptInterface.cpp
@@ -4542,7 +4542,7 @@ luaFunc(entity_getAnimationLoop)
 luaFunc(entity_move)
 {
 	Entity *e = entity(L);
-	bool ease = lua_tointeger(L, 5);
+    //bool ease = lua_tointeger(L, 5);
 	Vector p(lua_tonumber(L, 2), lua_tonumber(L, 3));
 	if (getBool(L, 6))
 		p = e->position + p;
@@ -7703,7 +7703,7 @@ luaFunc(getNearestEntity)
 	Vector p(lua_tonumber(L, 1), lua_tonumber(L, 2));
 	int radius = lua_tointeger(L, 3);
 	Entity *ignore = lua_isuserdata(L, 4) ? entity(L, 4) : NULL;
-	EntityType et = lua_isnumber(L, 5) ? (EntityType)lua_tointeger(L, 5) : ET_NOTYPE;
+    //EntityType et = lua_isnumber(L, 5) ? (EntityType)lua_tointeger(L, 5) : ET_NOTYPE;
 	DamageType dt = lua_isnumber(L, 6) ? (DamageType)lua_tointeger(L, 6) : DT_NONE;
 	int lrStart = lua_isnumber(L, 7) ? lua_tointeger(L, 7) : -1;
 	int lrEnd = lua_isnumber(L, 8) ? lua_tointeger(L, 8) : -1;
@@ -10590,7 +10590,7 @@ static const struct {
 #undef MK_ALIAS
 #define MK_FUNC(base, getter, prefix, suffix) luaRegister(prefix##_##suffix),
 #define MK_STR(s) #s
-#define MK_ALIAS(prefix, suffix, alias) {MK_STR(prefix)"_"MK_STR(alias), l_##prefix##_##suffix},
+#define MK_ALIAS(prefix, suffix, alias) {MK_STR(prefix) "_" MK_STR(alias), l_##prefix##_##suffix},
 
 	EXPAND_FUNC_PROTOTYPES
 

--- a/Aquaria/StatsAndAchievements.cpp
+++ b/Aquaria/StatsAndAchievements.cpp
@@ -92,7 +92,7 @@ const int FLAG_SPIRIT_DRASK					= 126;
 const int FLAG_SPIRIT_DRUNIAD				= 127;
 
 const int FLAG_TRANSTURTLE_VEIL01			= 130;
-const int FLAG_TRANSTURTLE_OPENWATER06		= 131;
+//const int FLAG_TRANSTURTLE_OPENWATER06		= 131;
 const int FLAG_TRANSTURTLE_FOREST04			= 132;
 const int FLAG_TRANSTURTLE_OPENWATER03		= 133;
 const int FLAG_TRANSTURTLE_FOREST05			= 134;
@@ -104,15 +104,15 @@ const int FLAG_TRANSTURTLE_FINALBOSS		= 139;
 
 const int FLAG_SEAHORSEBESTTIME				= 247;
 
-const int FLAG_MINIBOSS_START				= 700;
-const int FLAG_MINIBOSS_NAUTILUSPRIME		= 700;
+//const int FLAG_MINIBOSS_START				= 700;
+//const int FLAG_MINIBOSS_NAUTILUSPRIME		= 700;
 const int FLAG_MINIBOSS_KINGJELLY			= 701;
 const int FLAG_MINIBOSS_MERGOG				= 702;
 const int FLAG_MINIBOSS_CRAB				= 703;
 const int FLAG_MINIBOSS_OCTOMUN				= 704;
 const int FLAG_MINIBOSS_MANTISSHRIMP		= 705;
-const int FLAG_MINIBOSS_PRIESTS				= 706;
-const int FLAG_MINIBOSS_END					= 720;
+//const int FLAG_MINIBOSS_PRIESTS				= 706;
+//const int FLAG_MINIBOSS_END					= 720;
 
 
 //-----------------------------------------------------------------------------

--- a/Aquaria/StatsAndAchievements.h
+++ b/Aquaria/StatsAndAchievements.h
@@ -155,7 +155,7 @@ private:
 	// Should we store stats this frame?
 	bool storeStats;
 
-	PlayStats playStats;
+    // PlayStats playStats;
 
 	// Current Stat details
 	//float m_flGameFeetTraveled;

--- a/BBGE/AfterEffect.cpp
+++ b/BBGE/AfterEffect.cpp
@@ -264,8 +264,8 @@ void AfterEffectManager::renderGrid()
 	if (activeShader)
 		activeShader->unbind();
 
-	float width2 = float(vw)/2;
-	float height2 = float(vh)/2;
+    //float width2 = float(vw)/2;
+    //float height2 = float(vh)/2;
 
 
 	if(firstShader != lastShader)

--- a/BBGE/AfterEffect.h
+++ b/BBGE/AfterEffect.h
@@ -28,6 +28,7 @@ class Effect
 {
 public:
 	Effect();
+    virtual ~Effect(){};
 	virtual void go(){}
 	virtual void update(float dt, Vector ** drawGrid, int xDivs, int yDivs){}
 	bool done;

--- a/BBGE/Base.cpp
+++ b/BBGE/Base.cpp
@@ -221,11 +221,6 @@ static unsigned char charIsUpper(unsigned char c)
 	return c == upperToLowerTable[c];
 }
 
-static unsigned char charIsLower(unsigned char c)
-{
-	return c == lowerToUpperTable[c];
-}
-
 static unsigned char charToLower(unsigned char c)
 {
 	return upperToLowerTable[c];

--- a/BBGE/Base.cpp
+++ b/BBGE/Base.cpp
@@ -67,6 +67,13 @@ Vector getDirVector(Direction dir)
 	case DIR_RIGHT:
 		return Vector(1, 0);
 	break;
+    case DIR_UPLEFT:
+    case DIR_UPRIGHT:
+    case DIR_DOWNLEFT:
+    case DIR_DOWNRIGHT:
+    case DIR_MAX:
+    case DIR_NONE:
+        break;
 	}
 	return Vector(0,0);
 }
@@ -87,6 +94,13 @@ Direction getOppositeDir(Direction dir)
 	case DIR_RIGHT:
 		return DIR_LEFT;
 	break;
+    case DIR_UPLEFT:
+    case DIR_UPRIGHT:
+    case DIR_DOWNLEFT:
+    case DIR_DOWNRIGHT:
+    case DIR_MAX:
+    case DIR_NONE:
+        break;
 	}
 
 	return DIR_NONE;
@@ -108,6 +122,13 @@ Direction getNextDirClockwise(Direction dir)
 	case DIR_RIGHT:
 		return DIR_DOWN;
 		break;
+    case DIR_UPLEFT:
+    case DIR_UPRIGHT:
+    case DIR_DOWNLEFT:
+    case DIR_DOWNRIGHT:
+    case DIR_MAX:
+    case DIR_NONE:
+        break;
 	}
 	return DIR_NONE;
 }
@@ -591,7 +612,7 @@ void forEachFile(std::string path, std::string type, void callback(const std::st
 	    dirent *file=0;
 		while ( (file=readdir(dir)) != NULL )
 		{
-		    if (file->d_name && strlen(file->d_name) > 4)
+            if (strlen(file->d_name) > 4)
 		    {
                 debugLog(file->d_name);
                 char *extension=strrchr(file->d_name,'.');

--- a/BBGE/Core.cpp
+++ b/BBGE/Core.cpp
@@ -1280,35 +1280,6 @@ bool Core::createWindow(int width, int height, int bits, bool fullscreen, std::s
 #define M_PI           3.14159265358979323846
 #endif
 
-static void
-bbgePerspective(float fovy, float aspect, float zNear, float zFar)
-{
-    float sine, cotangent, deltaZ;
-    float radians = fovy / 2.0f * M_PI / 180.0f;
-
-    deltaZ = zFar - zNear;
-    sine = sinf(radians);
-    if ((deltaZ == 0.0f) || (sine == 0.0f) || (aspect == 0.0f)) {
-        return;
-    }
-    cotangent = cosf(radians) / sine;
-
-    GLfloat m[4][4] = {
-        { 1.0f, 0.0f, 0.0f, 0.0f },
-        { 0.0f, 1.0f, 0.0f, 0.0f },
-        { 0.0f, 0.0f, 1.0f, 0.0f },
-        { 0.0f, 0.0f, 0.0f, 1.0f }
-    };
-    m[0][0] = (GLfloat) (cotangent / aspect);
-    m[1][1] = (GLfloat) cotangent;
-    m[2][2] = (GLfloat) (-(zFar + zNear) / deltaZ);
-    m[2][3] = -1.0f;
-    m[3][2] = (GLfloat) (-2.0f * zNear * zFar / deltaZ);
-    m[3][3] = 0.0f;
-
-    glMultMatrixf(&m[0][0]);
-}
-
 void Core::setPixelScale(int pixelScaleX, int pixelScaleY)
 {
 
@@ -1564,8 +1535,7 @@ void Core::main(float runTime)
 
 	float dt;
 	float counter = 0;
-	int frames = 0;
-	float real_dt = 0;
+    int frames = 0;
 
 
 #if (!defined(_DEBUG) || defined(BBGE_BUILD_UNIX)) && defined(BBGE_BUILD_SDL)

--- a/BBGE/DebugFont.cpp
+++ b/BBGE/DebugFont.cpp
@@ -162,7 +162,12 @@ void DebugFont::setAlign(Align align)
 #include "../BBGE/Quad.h"
 
 DebugButton::DebugButton(int buttonID, DebugButtonReceiver *receiver, int bgWidth, int fsize, bool quitMain)
- : RenderObject(), label(0), highlight(0), quitMain(quitMain), receiver(receiver), buttonID(buttonID)
+    : RenderObject()
+    , label(0)
+    , quitMain(quitMain)
+    , buttonID(buttonID)
+    , highlight(0)
+    , receiver(receiver)
 {
 	if (bgWidth == 0)
 		bgWidth = 150;

--- a/BBGE/Effects.cpp
+++ b/BBGE/Effects.cpp
@@ -80,6 +80,10 @@ void PostProcessingFX::render()
 			FXTypes type = (FXTypes)i;
 			switch(type)
 			{
+            case FTX_NONE:
+                break;
+            case FXT_MAX:
+                break;
 			case FXT_RADIALBLUR:
 
 				float windowW = core->getWindowWidth();
@@ -148,7 +152,7 @@ void PostProcessingFX::render()
 				RenderObject::lastTextureApplied = 0;
 
 
-			break;
+            break;
 			}
 			glPopMatrix();
 

--- a/BBGE/Particles.h
+++ b/BBGE/Particles.h
@@ -185,7 +185,7 @@ protected:
 struct ParticleInfluence
 {
 	ParticleInfluence(Vector pos, float spd, float size, bool pull)
-		: pos(pos), spd(spd), size(size), pull(pull)
+        : pos(pos), size(size), spd(spd), pull(pull)
 	{}
 	ParticleInfluence() : size(0), spd(0), pull(false) {}
 	Vector pos;

--- a/BBGE/QuadTrail.cpp
+++ b/BBGE/QuadTrail.cpp
@@ -22,7 +22,10 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <assert.h>
 
 QuadTrail::QuadTrail(int maxPoints, float pointDist)
-: RenderObject(), maxPoints(maxPoints), pointDist(pointDist), numPoints(0)
+    : RenderObject()
+    , numPoints(0)
+    , maxPoints(maxPoints)
+    , pointDist(pointDist)
 {
 	quadTrailAlphaEffect = QTAE_NORMAL;
 	cull = false;

--- a/BBGE/Shader.cpp
+++ b/BBGE/Shader.cpp
@@ -114,9 +114,9 @@ void Shader::staticInit()
 	// everything fine when we are here
 	_useShaders = true;
 
-#endif
 
-end:
+    end:
+#endif
 
 	if (_useShaders)
 		debugLog("Shader support enabled.");

--- a/BBGE/Shader.cpp
+++ b/BBGE/Shader.cpp
@@ -329,14 +329,14 @@ void Shader::_setUniform(Uniform *u)
 {
 	switch(u->type)
 	{
-		case GL_FLOAT:          glUniform1fvARB(u->location, 1, u->data.f); break;
-		case GL_FLOAT_VEC2_ARB: glUniform2fvARB(u->location, 1, u->data.f); break;
-		case GL_FLOAT_VEC3_ARB: glUniform3fvARB(u->location, 1, u->data.f); break;
-		case GL_FLOAT_VEC4_ARB: glUniform4fvARB(u->location, 1, u->data.f); break;
-		case GL_INT:            glUniform1ivARB(u->location, 1, u->data.i); break;
-		case GL_INT_VEC2_ARB:   glUniform2ivARB(u->location, 1, u->data.i); break;
-		case GL_INT_VEC3_ARB:   glUniform3ivARB(u->location, 1, u->data.i); break;
-		case GL_INT_VEC4_ARB:   glUniform4ivARB(u->location, 1, u->data.i); break;
+        case GL_FLOAT:          glUniform1fvARB(u->location, 1, u->data.f.f); break;
+        case GL_FLOAT_VEC2_ARB: glUniform2fvARB(u->location, 1, u->data.f.f); break;
+        case GL_FLOAT_VEC3_ARB: glUniform3fvARB(u->location, 1, u->data.f.f); break;
+        case GL_FLOAT_VEC4_ARB: glUniform4fvARB(u->location, 1, u->data.f.f); break;
+        case GL_INT:            glUniform1ivARB(u->location, 1, u->data.i.i); break;
+        case GL_INT_VEC2_ARB:   glUniform2ivARB(u->location, 1, u->data.i.i); break;
+        case GL_INT_VEC3_ARB:   glUniform3ivARB(u->location, 1, u->data.i.i); break;
+        case GL_INT_VEC4_ARB:   glUniform4ivARB(u->location, 1, u->data.i.i); break;
 	}
 	u->dirty = false;
 }
@@ -432,10 +432,10 @@ void Shader::setInt(const char *name, int x, int y /* = 0 */, int z /* = 0 */, i
 	if(unsigned(idx) >= uniforms.size())
 		return;
 	Uniform& u = uniforms[idx];
-	u.data.i[0] = x;
-	u.data.i[1] = y;
-	u.data.i[2] = z;
-	u.data.i[3] = w;
+    u.data.i.i[0] = x;
+    u.data.i.i[1] = y;
+    u.data.i.i[2] = z;
+    u.data.i.i[3] = w;
 	u.dirty = true;
 	uniformsDirty = true;
 #endif
@@ -450,10 +450,10 @@ void Shader::setFloat(const char *name, float x, float y /* = 0 */, float z /* =
 	if(unsigned(idx) >= uniforms.size())
 		return;
 	Uniform& u = uniforms[idx];
-	u.data.f[0] = x;
-	u.data.f[1] = y;
-	u.data.f[2] = z;
-	u.data.f[3] = w;
+    u.data.f.f[0] = x;
+    u.data.f.f[1] = y;
+    u.data.f.f[2] = z;
+    u.data.f.f[3] = w;
 	u.dirty = true;
 	uniformsDirty = true;
 #endif

--- a/BBGE/Shader.h
+++ b/BBGE/Shader.h
@@ -62,14 +62,14 @@ private:
 		bool dirty; // need to flush if true
 		union
 		{
-			struct
+            struct si
 			{
 				int i[4];
-			};
-			struct
+            } i;
+            struct sf
 			{
 				float f[4];
-			};
+            } f;
 		} data;
 		char name[64];
 

--- a/BBGE/SkeletalSprite.cpp
+++ b/BBGE/SkeletalSprite.cpp
@@ -365,13 +365,13 @@ void BoneCommand::run()
 		if (e)
 			e->stop();
 	}
-	break;
+    break;
 	case AC_SET_PASS:
 		b->setRenderPass(slot);
 	break;
 	case AC_RESET_PASS:
 		b->setRenderPass(b->originalRenderPass);
-	break;
+    break;
 	}
 }
 

--- a/BBGE/SkeletalSprite.cpp
+++ b/BBGE/SkeletalSprite.cpp
@@ -372,6 +372,9 @@ void BoneCommand::run()
 	case AC_RESET_PASS:
 		b->setRenderPass(b->originalRenderPass);
     break;
+    case AC_SEGS_START:
+    case AC_SEGS_STOP:
+        break;
 	}
 }
 

--- a/BBGE/SkeletalSprite.h
+++ b/BBGE/SkeletalSprite.h
@@ -105,7 +105,7 @@ public:
 class BoneKeyframe
 {
 public:
-	BoneKeyframe() : idx(0), x(0), y(0), rot(0), doScale(0), sx(1), sy(1) {}
+    BoneKeyframe() : idx(0), x(0), y(0), rot(0), sx(1), sy(1), doScale(0) {}
 	int idx, x, y, rot;
 	float sx, sy;
 	bool doScale;

--- a/BBGE/SoundManager.cpp
+++ b/BBGE/SoundManager.cpp
@@ -72,7 +72,7 @@ namespace SoundCore
 	struct FadeCh
 	{
 	public:
-		FadeCh() : v(1), s(1), c(0), d(-1), to(0) {}
+        FadeCh() : c(0), v(1), s(1), to(0), d(-1) {}
 		FMOD::Channel *c;
 		float v,s,to;
 		int d;
@@ -410,6 +410,9 @@ void SoundManager::toggleEffectMusic(SoundEffectType effect, bool on)
 				dspFlange->remove();
 		}
 	break;
+    case SFX_NONE:
+    case SFX_MAX:
+        break;
 	}
 
 }

--- a/BBGE/SoundManager.h
+++ b/BBGE/SoundManager.h
@@ -84,9 +84,8 @@ enum SoundLoadType
 
 struct PlaySfx
 {
-	PlaySfx() : priority(0.5), handle(0), vol(1), fade(SFT_NONE),
-		time(0), freq(1), loops(0),
-		maxdist(0), x(0), y(0), relative(true), positional(false) {}
+    PlaySfx() : handle(0), vol(1), time(0), freq(1), loops(0), priority(0.5),
+        maxdist(0), fade(SFT_NONE), x(0), y(0), relative(true), positional(false) {}
 
 	std::string name;
 	intptr_t handle;

--- a/BBGE/Texture.cpp
+++ b/BBGE/Texture.cpp
@@ -230,7 +230,7 @@ bool Texture::load(std::string file)
 
 	size_t pos = file.find_last_of('.');
 
-	if ((pos != std::string::npos) && (pos >= 0))
+    if (pos != std::string::npos)
 	{
 		// make sure this didn't catch the '.' in /home/username/.Aquaria/*  --ryan.
 		const std::string userdata = core->getUserDataFolder();

--- a/ExternalLibs/ByteBuffer.h
+++ b/ExternalLibs/ByteBuffer.h
@@ -148,26 +148,26 @@ public:
 
 
 	ByteBuffer()
-		: _rpos(0), _wpos(0), _buf(NULL), _size(0), _growable(true), _res(0), _mybuf(false), _delfunc(NULL),
-		_allocfunc(NULL)
+                : _buf(NULL), _rpos(0), _wpos(0), _res(0), _size(0), _delfunc(NULL),
+                _allocfunc(NULL), _mybuf(false), _growable(true)
 	{
 	}
 	ByteBuffer(uint32 res)
-		: _rpos(0), _wpos(0), _buf(NULL), _size(0), _growable(true), _res(0), _mybuf(false), _delfunc(NULL),
-		_allocfunc(NULL)
+                : _buf(NULL), _rpos(0), _wpos(0), _res(0), _size(0), _delfunc(NULL),
+                  _allocfunc(NULL), _mybuf(false), _growable(true)
 	{
 		_allocate(res);
 	}
 	ByteBuffer(ByteBuffer &buf, Mode mode = COPY, uint32 extra = 0)
-		: _rpos(0), _wpos(0), _buf(NULL), _size(0), _growable(true), _res(0), _mybuf(false), _delfunc(NULL),
-		_allocfunc(NULL)
-	{
+                : _buf(NULL), _rpos(0), _wpos(0), _res(0), _size(0), _delfunc(NULL),
+                  _allocfunc(NULL), _mybuf(false), _growable(true)
+        {
 		init(buf, mode, extra);
 	}
 	// del param only used with TAKE_OVER, extra only used with COPY
 	ByteBuffer(void *buf, uint32 size, Mode mode = COPY, delete_func del = NULL, uint32 extra = 0)
-		: _rpos(0), _wpos(0), _size(size), _buf(NULL), _growable(true), _delfunc(del),
-		_mybuf(false), _allocfunc(NULL) // for mode == REUSE
+                : _buf(NULL), _rpos(0), _wpos(0), _res(0), _size(0), _delfunc(NULL),
+                  _allocfunc(NULL), _mybuf(false), _growable(true)  // for mode == REUSE
 	{
 		init(buf, size, mode, del, extra);
 	}

--- a/ExternalLibs/DeflateCompressor.cpp
+++ b/ExternalLibs/DeflateCompressor.cpp
@@ -9,9 +9,9 @@
 
 DeflateCompressor::DeflateCompressor()
 :   _windowBits(-MAX_WBITS), // negative, because we want a raw deflate stream, and not zlib-wrapped
+    _real_size(0),
     _forceCompress(false),
-    _iscompressed(false),
-    _real_size(0)
+    _iscompressed(false)
 {
 }
 

--- a/ExternalLibs/freetype2/src/cff/cffload.c
+++ b/ExternalLibs/freetype2/src/cff/cffload.c
@@ -1255,7 +1255,7 @@
     /* set defaults */
     FT_MEM_ZERO( top, sizeof ( *top ) );
 
-    top->underline_position  = -100L & ~((1L<<16)-1);
+    top->underline_position  = -100L * (1<<16);
     top->underline_thickness = 50L << 16;
     top->charstring_type     = 2;
     top->font_matrix.xx      = 0x10000L;

--- a/ExternalLibs/freetype2/src/cff/cffload.c
+++ b/ExternalLibs/freetype2/src/cff/cffload.c
@@ -1255,7 +1255,7 @@
     /* set defaults */
     FT_MEM_ZERO( top, sizeof ( *top ) );
 
-    top->underline_position  = -100L << 16;
+    top->underline_position  = -100L & ~((1L<<16)-1);
     top->underline_thickness = 50L << 16;
     top->charstring_type     = 2;
     top->font_matrix.xx      = 0x10000L;

--- a/ExternalLibs/glm/core/func_integer.inl
+++ b/ExternalLibs/glm/core/func_integer.inl
@@ -88,7 +88,7 @@ namespace glm
 			if(x > y)
 				return genUType(detail::highp_int_t(x) - detail::highp_int_t(y));
 			else
-				return genUType(detail::highp_int_t(1) << detail::highp_int_t(32) + detail::highp_int_t(x) - detail::highp_int_t(y));
+                                return genUType(detail::highp_int_t(1) << (detail::highp_int_t(32) + detail::highp_int_t(x) - detail::highp_int_t(y)));
 		}
 
 		template <typename T>

--- a/ExternalLibs/glm/core/type_half.inl
+++ b/ExternalLibs/glm/core/type_half.inl
@@ -116,9 +116,9 @@ namespace detail
 		// of float and half (127 versus 15).
 		//
 
-		register int s =  (i >> 16) & 0x00008000;
-		register int e = ((i >> 23) & 0x000000ff) - (127 - 15);
-		register int m =   i        & 0x007fffff;
+                int s =  (i >> 16) & 0x00008000;
+                int e = ((i >> 23) & 0x000000ff) - (127 - 15);
+                int m =   i        & 0x007fffff;
 
 		//
 		// Now reassemble s, e and m into a half:

--- a/ExternalLibs/glpng/zlib/inflate.c
+++ b/ExternalLibs/glpng/zlib/inflate.c
@@ -1472,7 +1472,7 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
+    if (strm == Z_NULL || strm->state == Z_NULL) return -1L & ~((1L<<16)-1);
     state = (struct inflate_state FAR *)strm->state;
     return ((long)(state->back) << 16) +
         (state->mode == COPY ? state->length :

--- a/ExternalLibs/glpng/zlib/inflate.c
+++ b/ExternalLibs/glpng/zlib/inflate.c
@@ -1472,7 +1472,7 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L & ~((1L<<16)-1);
+    if (strm == Z_NULL || strm->state == Z_NULL) return -1L * (1<<16);
     state = (struct inflate_state FAR *)strm->state;
     return ((long)(state->back) << 16) +
         (state->mode == COPY ? state->length :

--- a/ExternalLibs/libvorbis-1.3.3/lib/codebook.c
+++ b/ExternalLibs/libvorbis-1.3.3/lib/codebook.c
@@ -450,7 +450,8 @@ long vorbis_book_decodev_set(codebook *book,float *a,oggpack_buffer *b,int n){
       }
     }
   }else{
-    int i,j;
+    int i;
+    //int j;
 
     for(i=0;i<n;){
       a[i++]=0.f;

--- a/ExternalLibs/lua-5.1.4/src/lauxlib.c
+++ b/ExternalLibs/lua-5.1.4/src/lauxlib.c
@@ -574,7 +574,8 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     /* skip eventual `#!...' */
-   while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) ;
+    while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0])
+       ;
     lf.extraline = 0;
   }
   ungetc(c, lf.f);

--- a/ExternalLibs/minihttp.cpp
+++ b/ExternalLibs/minihttp.cpp
@@ -187,8 +187,12 @@ static bool _SetNonBlocking(SOCKET s, bool nonblock)
 }
 
 TcpSocket::TcpSocket()
-: _s(INVALID_SOCKET), _inbuf(NULL), _inbufSize(0), _recvSize(0),
-  _readptr(NULL), _lastport(0)
+    : _inbuf(NULL)
+    , _readptr(NULL)
+    , _inbufSize(0)
+    , _recvSize(0)
+    , _lastport(0)
+    , _s(INVALID_SOCKET)
 {
 }
 
@@ -388,9 +392,15 @@ static void strToLower(std::string& s)
 }
 
 HttpSocket::HttpSocket()
-: TcpSocket(),
-_keep_alive(0), _remaining(0), _chunkedTransfer(false), _mustClose(true), _inProgress(false),
-_followRedir(true), _alwaysHandle(false), _status(0)
+    : TcpSocket()
+    , _keep_alive(0)
+    , _remaining(0)
+    , _status(0)
+    , _inProgress(false)
+    , _chunkedTransfer(false)
+    , _mustClose(true)
+    , _followRedir(true)
+    , _alwaysHandle(false)
 {
 }
 

--- a/ExternalLibs/ttvfs/VFSDefines.h
+++ b/ExternalLibs/ttvfs/VFSDefines.h
@@ -50,7 +50,7 @@ VFS_NAMESPACE_START
      static const vfspos npos = vfspos(-1i64);
 #else
 #    define VFS_STRICMP strcasecmp
-     static const vfspos npos = vfspos(-1LL);
+     static const vfspos npos = vfspos(~0L);
 #endif
 
 typedef void (*delete_func)(void *);

--- a/ExternalLibs/ttvfs/VFSDir.cpp
+++ b/ExternalLibs/ttvfs/VFSDir.cpp
@@ -59,7 +59,7 @@ std::pair<DirBase*, DirBase*> DirBase::_getDirEx(const char *subdir, const char 
         return std::make_pair(this, this);
 
     DirBase *ret = NULL;
-    DirBase *last = NULL;
+    //DirBase *last = NULL;
     char *slashpos = (char *)strchr(subdir, '/');
 
     // if there is a '/' in the string, descend into subdir and continue there

--- a/ExternalLibs/ttvfs/VFSDirInternal.cpp
+++ b/ExternalLibs/ttvfs/VFSDirInternal.cpp
@@ -106,12 +106,6 @@ void InternalDir::forEachFile(FileEnumCallback f, void *user /* = NULL */, bool 
         f(it->second, user);
 }
 
-static void _iterDirs(Dirs &m, DirEnumCallback f, void *user)
-{
-    for(Dirs::iterator it = m.begin(); it != m.end(); ++it)
-        f(it->second.content(), user);
-}
-
 void InternalDir::forEachDir(DirEnumCallback f, void *user /* = NULL */, bool safe /* = false */)
 {
     for(MountedDirs::reverse_iterator it = _mountedDirs.rbegin(); it != _mountedDirs.rend(); ++it)

--- a/ExternalLibs/ttvfs/VFSFile.cpp
+++ b/ExternalLibs/ttvfs/VFSFile.cpp
@@ -95,7 +95,7 @@ vfspos DiskFile::size()
 // ------------- MemFile -----------------------
 
 MemFile::MemFile(const char *name, void *buf, unsigned int size, delete_func delfunc /* = NULL */, DeleteMode delmode /* = ON_CLOSE */)
-: File(name), _pos(0), _size(size), _buf(buf), _delfunc(delfunc), _delmode(delmode)
+: File(name), _buf(buf), _pos(0), _size(size), _delfunc(delfunc), _delmode(delmode)
 {
 }
 

--- a/ExternalLibs/ttvfs/VFSRefcounted.h
+++ b/ExternalLibs/ttvfs/VFSRefcounted.h
@@ -37,6 +37,7 @@ public:
     {
         int val = s_getRef(_refcount);
         assert(val == 0 && "Object was deleted with refcount != 0");
+        val = 0; // prevents unused warning
     }
 
     inline void incref()

--- a/ExternalLibs/ttvfs_zip/VFSFileZip.cpp
+++ b/ExternalLibs/ttvfs_zip/VFSFileZip.cpp
@@ -143,7 +143,7 @@ bool ZipFile::unpack()
     close(); // delete the buffer
 
     const vfspos sz = size(); // will reopen the file
-    if(sz < 0)
+    if(sz == npos)
         return false;
 
     _buf = new char[sz + 1];

--- a/ExternalLibs/ttvfs_zip/miniz.c
+++ b/ExternalLibs/ttvfs_zip/miniz.c
@@ -4017,7 +4017,7 @@ mz_bool mz_zip_writer_init_from_reader(mz_zip_archive *pZip, const char *pFilena
   if (pState->m_pFile)
   {
 #ifdef MINIZ_NO_STDIO
-    pFilename; return MZ_FALSE;
+    return MZ_FALSE;
 #else
     // Archive is being read from stdio - try to reopen as writable.
     if (pZip->m_pIO_opaque != pZip)


### PR DESCRIPTION
Tested against "-Wall -pedantic" with gnu99/gnu++11 standards using clang 3.9 on Linux. The only warnings remaining for me right now are:
- Unused function StartAQConfig(): Seems to be used on Windows
- Unused function compile_time_assertions(): Probably needed for compile time checks?
- Extended field designator is an extension: Not sure how to fix those
- Use of tmpnam instead of mkstemp in lua

This is for #23.

I messed up some indentations there because I'd forgotten to set the project's whitespace style, if that's an issue I can go over the changes again. Before this is merged, somebody should probably do a Windows build.