### PR TITLE
Force desktop OpenGL

### DIFF
--- a/BBGE/Window_SDL2.cpp
+++ b/BBGE/Window_SDL2.cpp
@@ -66,6 +66,9 @@ void Window::_open(unsigned w, unsigned h, bool full, unsigned bpp, bool vsync, 
 #  endif
 	SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2 );
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1 );
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0 );
 	SDL_SetHint("SDL_VIDEO_HIGHDPI_DISABLED", "1");
 
 	Uint32 flags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;


### PR DESCRIPTION
When SDL2 is compiled without video-opengl, it allows using desktop OpenGL API, but not by default, so Aquaria is showing only black screen. Instead, let's explicitly set minimum version and profile mask. I've used the same values, as SDL2 is using (when compiled with video-opengl, https://github.com/spurious/SDL-mirror/blob/release-2.0.12/src/video/SDL_video.c#L3119-L3122)