### PR TITLE
Compatibility with non-standard build environments

### DIFF
--- a/Aquaria/ScriptInterface.cpp
+++ b/Aquaria/ScriptInterface.cpp
@@ -1,4 +1,4 @@
-#/*
+/*
 Copyright (C) 2007, 2010 - Bit-Blot
 
 This file is part of Aquaria.
@@ -41,6 +41,8 @@ extern "C"
 #include "Gradient.h"
 
 #include "../BBGE/MathFunctions.h"
+
+#undef quad // avoid conflict with quad precision types
 
 // Define this to 1 to check types of pointers passed to functions,
 // and warn if a type mismatch is detected. In this case,

--- a/BBGE/Base.cpp
+++ b/BBGE/Base.cpp
@@ -21,6 +21,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "Base.h"
 #include "Core.h"
 #include <algorithm>
+#include <signal.h>
 
 #ifdef BBGE_BUILD_WINDOWS
 	#include <shellapi.h>

--- a/BBGE/FrameBuffer.cpp
+++ b/BBGE/FrameBuffer.cpp
@@ -23,7 +23,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 //WARNING: FrameBuffer objects have to have reloadDevice/unloadDevice called manually!
 
-#ifdef BBGE_BUILD_FRAMEBUFFER
+#if defined(BBGE_BUILD_FRAMEBUFFER) && defined(BBGE_BUILD_OPENGL_DYNAMIC)
 	PFNGLISRENDERBUFFEREXTPROC glIsRenderbufferEXT = NULL;
 	PFNGLBINDRENDERBUFFEREXTPROC glBindRenderbufferEXT = NULL;
 	PFNGLDELETERENDERBUFFERSEXTPROC glDeleteRenderbuffersEXT = NULL;
@@ -131,6 +131,7 @@ bool FrameBuffer::init(int width, int height, bool fitToScreen, GLint filter)
 	}
 	else
 	{
+#if defined(BBGE_BUILD_OPENGL_DYNAMIC)
 		if (!glIsRenderbufferEXT)
 		{
 			glIsRenderbufferEXT = (PFNGLISRENDERBUFFEREXTPROC)SDL_GL_GetProcAddress("glIsRenderbufferEXT");
@@ -162,6 +163,7 @@ bool FrameBuffer::init(int width, int height, bool fitToScreen, GLint filter)
 			debugLog("One or more EXT_framebuffer_object functions were not found");
 			return false;
 		}
+#endif
 
 		//
 		// Create a frame-buffer object and a render-buffer object...

--- a/BBGE/Shader.cpp
+++ b/BBGE/Shader.cpp
@@ -22,7 +22,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "Shader.h"
 #include "algorithmx.h"
 
-#ifdef BBGE_BUILD_SHADERS
+#if defined(BBGE_BUILD_SHADERS) && defined(BBGE_BUILD_OPENGL_DYNAMIC)
 	// GL_ARB_shader_objects
 	PFNGLCREATEPROGRAMOBJECTARBPROC  glCreateProgramObjectARB  = NULL;
 	PFNGLDELETEOBJECTARBPROC         glDeleteObjectARB		 = NULL;
@@ -77,6 +77,7 @@ void Shader::staticInit()
 	}
 	else
 	{
+#if defined(BBGE_BUILD_OPENGL_DYNAMIC)
 		glCreateProgramObjectARB  = (PFNGLCREATEPROGRAMOBJECTARBPROC)SDL_GL_GetProcAddress("glCreateProgramObjectARB");
 		glDeleteObjectARB         = (PFNGLDELETEOBJECTARBPROC)SDL_GL_GetProcAddress("glDeleteObjectARB");
 		glUseProgramObjectARB     = (PFNGLUSEPROGRAMOBJECTARBPROC)SDL_GL_GetProcAddress("glUseProgramObjectARB");
@@ -110,6 +111,7 @@ void Shader::staticInit()
 			goto end;
 		}
 	}
+#endif
 
 	// everything fine when we are here
 	_useShaders = true;


### PR DESCRIPTION
1. Systems which define `quad` as an alias to [`quad_t` ](https://developer.apple.com/documentation/kernel/quad_t) type will break the following macro:

    MAKE_QUAD_FUNCS(_, quad)

2. Pointers to GL extension such as `glBindFramebufferEXT` should not be declared if `BBGE_BUILD_OPENGL_DYNAMIC` is not defined. This allows static linking to GL extensions.

3. `master` branch contained a fix for Raspberry Pi build, merged here.