### PR TITLE
Fixed SDL2 and OpenAL references

### DIFF
--- a/BBGE/Core.cpp
+++ b/BBGE/Core.cpp
@@ -67,7 +67,7 @@ Core *core = 0;
 	HICON icon_windows = 0;
 #endif
 
-#ifndef KMOD_GUI
+#if !defined KMOD_GUI && !SDL_VERSION_ATLEAST(2, 0, 14)
 	#define KMOD_GUI KMOD_META
 #endif
 

--- a/BBGE/FmodOpenALBridge.cpp
+++ b/BBGE/FmodOpenALBridge.cpp
@@ -36,8 +36,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "FmodOpenALBridge.h"
 
-#include "al.h"
-#include "alc.h"
+#include "AL/al.h"
+#include "AL/alc.h"
 
 #include "ogg/ogg.h"
 #include "vorbis/vorbisfile.h"

--- a/BBGE/FmodOpenALBridge.cpp
+++ b/BBGE/FmodOpenALBridge.cpp
@@ -36,8 +36,8 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 #include "FmodOpenALBridge.h"
 
-#include "AL/al.h"
-#include "AL/alc.h"
+#include "al.h"
+#include "alc.h"
 
 #include "ogg/ogg.h"
 #include "vorbis/vorbisfile.h"


### PR DESCRIPTION
SDL 2.0.14 changes `KMOD_GUI` to an enum rather than a define, resulting in a build failure when trying to compile with current versions of SDL 2.  I'm not sure whether the OpenAL header location change affects people on other operating systems, but it did impact me, as my compiler couldn't find those headers referenced by `FmodOpenALBridge.cpp`.

This fixes both of those issues.