### PR TITLE
Remove texture reutilisation when the texture loading failed.

### DIFF
--- a/BBGE/Core.cpp
+++ b/BBGE/Core.cpp
@@ -4500,7 +4500,9 @@ CountedPtr<Texture> Core::addTexture(const std::string &textureName, TextureLoad
 	else
 		texResult = doTextureAdd(texture, loadName, internalTextureName);
 
-	addTexture(texResult.first.content());
+	if (texResult.second != TEX_FAILED) {
+		addTexture(texResult.first.content());
+	}
 
 	if(debugLogTextures)
 	{

--- a/BBGE/RenderObject.cpp
+++ b/BBGE/RenderObject.cpp
@@ -1368,9 +1368,6 @@ bool RenderObject::setTexture(const std::string &n)
 		return false;
 	}
 
-	if(texture && name == texture->name)
-		return true; // no texture change
-
 	TextureLoadResult res = TEX_FAILED;
 	CountedPtr<Texture> tex = core->addTexture(name, &res);
 	setTexturePointer(tex);


### PR DESCRIPTION
There is an error in the game that makes it load an empty white texture when there is no cape to load and the game put it transparent. So everything is fine. But, sometimes, the cape is reloaded and since the false texture has been put in the game resources, it is considered valid and shown.

![image](https://github.com/AquariaOSE/Aquaria/assets/1783758/114b21de-2910-421c-9e96-e89d861c0c6c)

So in this pull request, I disable the resources reuse for texture that has failed to load.