### PR TITLE
fix build with tinyxml2 6.0.0 or later

### DIFF
--- a/Aquaria/Continuity.cpp
+++ b/Aquaria/Continuity.cpp
@@ -2737,7 +2737,11 @@ void Continuity::loadFileData(int slot, XMLDocument &doc)
 		}
 		if (doc.Parse(buf, size) != XML_SUCCESS)
 		{
+#if TINYXML2_MAJOR_VERSION < 6
 			errorLog("Failed to load save data: " + teh_file + " -- Error: " + doc.GetErrorStr1());
+#else
+			errorLog("Failed to load save data: " + teh_file + " -- Error: " + doc.ErrorStr());
+#endif
 			return;
 		}
 	}

--- a/Aquaria/DSQ.cpp
+++ b/Aquaria/DSQ.cpp
@@ -2079,7 +2079,11 @@ void DSQ::loadModsCallback(const std::string &filename, intptr_t param)
 	if(!Mod::loadModXML(&d, name))
 	{
 		std::ostringstream os;
+#if TINYXML2_MAJOR_VERSION < 6
 		os << "Failed to load mod xml: " << filename << " -- Error: " << d.GetErrorStr1();
+#else
+		os << "Failed to load mod xml: " << filename << " -- Error: " << d.ErrorStr();
+#endif
 		dsq->debugLog(os.str());
 		return;
 	}


### PR DESCRIPTION
Error handling API changed in 6.0.0.

Reference:
https://github.com/leethomason/tinyxml2/commit/4155ac0c7345c760be0b79d44040691a5c4fff06