### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/ExternalLibs/freetype2/src/pshinter/pshalgo.c
+++ b/ExternalLibs/freetype2/src/pshinter/pshalgo.c
@@ -1690,7 +1690,10 @@
     /* process secondary hints to `selected' points */
     if ( num_masks > 1 && glyph->num_points > 0 )
     {
-      first = mask->end_point;
+      /* the `endchar' op can reduce the number of points */
+      first = mask->end_point > glyph->num_points
+                ? glyph->num_points
+                : mask->end_point;
       mask++;
       for ( ; num_masks > 1; num_masks--, mask++ )
       {
@@ -1698,7 +1701,9 @@
         FT_Int   count;
 
 
-        next  = mask->end_point;
+        next  = mask->end_point > glyph->num_points
+                  ? glyph->num_points
+                  : mask->end_point;
         count = next - first;
         if ( count > 0 )
         {


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `psh_glyph_find_strong_points` that was cloned from `freetype/freetype` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `psh_glyph_find_strong_points` in `ExternalLibs/freetype2/src/pshinter/pshalgo.c`
* **Original Fix**: https://github.com/freetype/freetype/commit/8d22746c9e5af80ff4304aef440986403a5072e2

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/freetype/freetype/commit/8d22746c9e5af80ff4304aef440986403a5072e2
* [CVE-2010-2498](https://nvd.nist.gov/vuln/detail/cve-2010-2498)

Please review and merge this PR to ensure your repository is protected against this vulnerability.