### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/ExternalLibs/lua-5.1.4/src/ldo.c
+++ b/ExternalLibs/lua-5.1.4/src/ldo.c
@@ -494,7 +494,7 @@ static void f_parser (lua_State *L, void *ud) {
   struct SParser *p = cast(struct SParser *, ud);
   int c = luaZ_lookahead(p->z);
   luaC_checkGC(L);
-  tf = ((c == LUA_SIGNATURE[0]) ? luaU_undump : luaY_parser)(L, p->z,
+  tf = (luaY_parser)(L, p->z,
                                                              &p->buff, p->name);
   cl = luaF_newLclosure(L, tf->nups, hvalue(gt(L)));
   cl->l.p = tf;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `f_parser` that was cloned from `antirez/redis` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `f_parser` in `ExternalLibs/lua-5.1.4/src/ldo.c`
* **Original Fix**: https://github.com/antirez/redis/commit/fdf9d455098f54f7666c702ae464e6ea21e25411

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/antirez/redis/commit/fdf9d455098f54f7666c702ae464e6ea21e25411
* [CVE-2015-4335
](https://nvd.nist.gov/vuln/detail/CVE-2015-4335)
Please review and merge this PR to ensure your repository is protected against this vulnerability.