### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/ExternalLibs/lua-5.1.4/src/ldo.c
+++ b/ExternalLibs/lua-5.1.4/src/ldo.c
@@ -494,7 +494,7 @@ static void f_parser (lua_State *L, void *ud) {
   struct SParser *p = cast(struct SParser *, ud);
   int c = luaZ_lookahead(p->z);
   luaC_checkGC(L);
-  tf = ((c == LUA_SIGNATURE[0]) ? luaU_undump : luaY_parser)(L, p->z,
+  tf = (luaY_parser)(L, p->z,
                                                              &p->buff, p->name);
   cl = luaF_newLclosure(L, tf->nups, hvalue(gt(L)));
   cl->l.p = tf;


### PR DESCRIPTION

## Summary
This PR fixes a potential security vulnerability in cloned code that appears to have missed an upstream security patch.

## Details
- **Affected file**: `ExternalLibs/lua-5.1.4/src/ldo.c` 
- **Upstream fix commit**: https://github.com/antirez/redis/commit/fdf9d455098f54f7666c702ae464e6ea21e25411
- **Clone similarity score**:  0.9999710321426392

## What this PR does
- Applies the upstream security fix logic to the cloned implementation in this repository.


## References:
- https://nvd.nist.gov/vuln/detail/CVE-2015-4335

Please review and merge this PR to ensure your repository is protected against this potential vulnerability. 
Thank you for your time !
